### PR TITLE
fix: decode song title before fetching it

### DIFF
--- a/src/app/(main)/[title]/layout.tsx
+++ b/src/app/(main)/[title]/layout.tsx
@@ -18,7 +18,10 @@ export default async function MusicLayout({
   children,
   params,
 }: MusicLayoutProps) {
-  const song = await getSongByTitle(outputs.song, params.title)
+  const song = await getSongByTitle(
+    outputs.song,
+    decodeURIComponent(params.title),
+  )
   const associatedAlbum =
     typeof song.album_id === 'number'
       ? await getAlbum(outputs.album, song.album_id)


### PR DESCRIPTION
# Goal

Following last PR #4 , displaying a song would crash the app.

The issue was the fetch of a song from its title, with a title being encoded for URL params but non decoded for fetching.