### PR TITLE
fix: sidenav's title's backgrounds should not only be displayed when …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starrymusic",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/components/client/TitlesList.tsx
+++ b/src/components/client/TitlesList.tsx
@@ -86,9 +86,9 @@ export const TitlesList = ({ titles, context }: TitlesListProps) => {
           <tr
             key={`${title}:${index}`}
             className={clsx('cursor-pointer dark:hover:bg-pink-600/50', {
-              'bg-pink-200 dark:bg-pink-800': decodedPathName.includes(
-                `/${title}`,
-              ),
+              'bg-pink-200 dark:bg-pink-800':
+                decodedPathName.includes(`/${title}/`) ||
+                decodedPathName.endsWith(`/${title}`),
               'hover:bg-pink-600/10': !decodedPathName.includes(`/${title}/`),
             })}
             onClick={() => redirectToTitle(title)}


### PR DESCRIPTION
…the url contains it

For example, being on the Timeshift album page was highlighting the Timeshift song.